### PR TITLE
Catch TypeError when query has no results

### DIFF
--- a/packages/cli/src/helper/util.ts
+++ b/packages/cli/src/helper/util.ts
@@ -30,16 +30,10 @@ export interface Flags extends Options {
 export type Apicall<A extends unknown[], Return> = (...a: A) => Promise<Return>;
 
 export function showTable(data: object[], flags: Options) {
-  try {
-    const columns = Object.getOwnPropertyNames(data?.[0]);
-    const col = columns.reduce((obj, cur) => ({ ...obj, [cur]: { header: cur } }), {});
-    cli.table(data, col, { ...flags });
-  }
-  catch (TypeError) {
-    if (Object.keys(data).length != 0) {
-      throw TypeError
-    }
-  }
+  const columns = Object.getOwnPropertyNames(data?.[0]);
+  const col = columns.reduce((obj, cur) => ({ ...obj, [cur]: { header: cur } }), {});
+
+  cli.table(data, col, { ...flags });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/cli/src/helper/util.ts
+++ b/packages/cli/src/helper/util.ts
@@ -30,7 +30,7 @@ export interface Flags extends Options {
 export type Apicall<A extends unknown[], Return> = (...a: A) => Promise<Return>;
 
 export function showTable(data: object[], flags: Options) {
-  const columns = Object.getOwnPropertyNames(data?.[0]);
+  const columns = Object.getOwnPropertyNames(data?.[0] ?? {});
   const col = columns.reduce((obj, cur) => ({ ...obj, [cur]: { header: cur } }), {});
 
   cli.table(data, col, { ...flags });

--- a/packages/cli/src/helper/util.ts
+++ b/packages/cli/src/helper/util.ts
@@ -30,10 +30,16 @@ export interface Flags extends Options {
 export type Apicall<A extends unknown[], Return> = (...a: A) => Promise<Return>;
 
 export function showTable(data: object[], flags: Options) {
-  const columns = Object.getOwnPropertyNames(data?.[0]);
-  const col = columns.reduce((obj, cur) => ({ ...obj, [cur]: { header: cur } }), {});
-
-  cli.table(data, col, { ...flags });
+  try {
+    const columns = Object.getOwnPropertyNames(data?.[0]);
+    const col = columns.reduce((obj, cur) => ({ ...obj, [cur]: { header: cur } }), {});
+    cli.table(data, col, { ...flags });
+  }
+  catch (TypeError) {
+    if (Object.keys(data).length != 0) {
+      throw TypeError
+    }
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Addresses #4.
Before, when a query had no results:

     ›   Error: 
     ›
     ›   {}
     ›
     ›   TypeError: Cannot convert undefined or null to object
     ›

Now, nothing is returned.
When `TypeError` occurs, it's caught. If the query result's length is zero, that means that it ran successfully but had no results. No errors are thrown. On the other hand, if it ran unsuccessfully, the error is rethrown.