### PR TITLE
Add `validate query` command to rscode

### DIFF
--- a/packages/rscode/package.json
+++ b/packages/rscode/package.json
@@ -20,7 +20,8 @@
   ],
   "activationEvents": [
     "onLanguage:rsql",
-    "onCommand:extension.rocksetRun"
+    "onCommand:extension.rocksetRun",
+    "onCommand:extension.rocksetValidate"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/packages/rscode/package.json
+++ b/packages/rscode/package.json
@@ -43,6 +43,10 @@
       {
         "command": "extension.rocksetRun",
         "title": "Execute Rockset Query"
+      },
+      {
+        "command": "extension.rocksetValidate",
+        "title": "Validate Rockset Query"
       }
     ],
     "languages": [
@@ -103,6 +107,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "glob": "^7.1.4",
     "handlebars": "^4.7.6",
+    "jest": "^26.6.3",
     "ts-loader": "^8.0.0",
     "ts-node": "^8.10.2",
     "typescript": "^3.8.3",

--- a/packages/rscode/src/extension.ts
+++ b/packages/rscode/src/extension.ts
@@ -121,6 +121,32 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
+  // VALIDATE QUERY COMMAND
+  const validate_query = vscode.commands.registerTextEditorCommand(
+    'extension.rocksetValidate',
+    async (activeEditor) => {
+      const text = activeEditor.document.getText();
+      
+      channel.append(`
+*** Rockset Query Text: ***
+${text}\n\n`);
+
+      channel.append(`
+*** Rockset Query Validation: ***`)
+
+      try {
+        await client.queries.validate({ sql: { query: text } }) // try validation
+        channel.append("\nSUCCESS")
+        channel.show();
+      } catch (e) { // if failed, log error
+        channel.append(`\nFAIL: ${e.message}`); // log error
+        channel.show();
+        await vscode.window.showErrorMessage(e.message); // show vscode error
+      }
+    }
+  );
+
+  // EXECUTE QUERY COMMAND
   // The command has been defined in the package.json file
   // The commandId parameter must match the command field in package.json
   // This function is called when this command id is run
@@ -196,7 +222,7 @@ ${text}
     '.', // triggered whenever a '.' is being typed
     ':'
   );
-  context.subscriptions.push(disposable, rocksetAutoComplete);
+  context.subscriptions.push(disposable, rocksetAutoComplete, validate_query);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
There is now a `validate query` command for the vscode extension.
![Screen Shot 2021-05-16 at 5 00 23 PM](https://user-images.githubusercontent.com/69025547/118417358-93f39400-b668-11eb-855d-aa0ea540fada.png)

Successful query:
![Screen Shot 2021-05-16 at 5 02 08 PM](https://user-images.githubusercontent.com/69025547/118417368-9b1aa200-b668-11eb-9e6e-9901f4c172ee.png)

Failed query:
![Screen Shot 2021-05-16 at 5 02 44 PM](https://user-images.githubusercontent.com/69025547/118417376-a968be00-b668-11eb-987f-54a6d10bac9b.png)
