### PR TITLE
Skip preflight check in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+    env:
+      SKIP_PREFLIGHT_CHECK: true
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Summary:
Skip preflight check as in the build pipeline.
If the check is there, then the build does not succeed because of an incompatibility in versions of eslint in create-react-app compared to the rockset-js repo.
https://github.com/facebook/create-react-app/issues/11119