### PR TITLE
Add boolean to supported parameters in dev-ui

### DIFF
--- a/packages/dev-ui/src/pages/QueryParams.tsx
+++ b/packages/dev-ui/src/pages/QueryParams.tsx
@@ -33,6 +33,7 @@ export const SUPPORTED_PARAMS = [
   'string',
   'int',
   'float',
+  'bool',
   'date',
   'datetime',
   'time',


### PR DESCRIPTION
Adds `bool` to available parameter types in dev ui.

![Screen Shot 2022-09-30 at 6 06 33 PM](https://user-images.githubusercontent.com/69025547/193377241-cbc0d4c8-9bcb-43d2-88ce-ec12a44a946c.png)
