### PR TITLE
[DEX-25] add openapi spec to rockset-js

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec"]
+	path = spec
+	url = https://github.com/rockset/rockset-js

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "spec"]
-	path = spec
-	url = https://github.com/rockset/rockset-js

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec"]
+	path = spec
+	url = https://github.com/rockset/openapi

--- a/packages/client/src/tests/functionality.test.ts
+++ b/packages/client/src/tests/functionality.test.ts
@@ -206,7 +206,7 @@ describe('functionality tests (e2e)', function () {
       const error: ErrorModel = e;
       expect(error).toMatchObject({
         message:
-          'Query Lambda "myFakeQuery" not found in workspace "commons.fake.workspace".',
+          'Query Lambda "myFakeQuery" (version "not_a_version") not found in workspace "commons.fake.workspace".',
         type: 'NOTFOUND',
         line: null,
         column: null,


### PR DESCRIPTION
- Add openapi spec as a submodule
- Fix nonexistent QL e2e test